### PR TITLE
Added the minuteman plugin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,17 @@ export GOOS?=linux
 # the hierarchical structure of an existing $GOPATH directory.
 export GOPATH=$(shell pwd)/gopath
 
+ifeq ($(VERBOSE),1)
+	TEST_VERBOSE=-ginkgo.v
+endif
+
 #dcos-l4lb
 L4LB=github.com/dcos/dcos-cni/plugins/l4lb
 L4LB_SRC=$(wildcard plugins/l4lb/*.go) $(wildcard pkg/spartan/*.go)
+L4LB_TEST_SRC=$(wildcard plugins/l4lbl/*_tests.go)
 
 PLUGINS=dcos-l4lb
+TESTS=dcos-l4lb-test
 
 .PHONY: all plugin
 default: all
@@ -40,6 +46,12 @@ dcos-l4lb:$(L4LB_SRC)
 	go build -v -o `pwd`/bin/$@ $(L4LB)
 
 plugin: gopath vendor $(PLUGINS)
+
+dcos-l4lb-test:$(L4LB_TEST_SRC)
+	echo "GOPATH:" $(GOPATH)
+	go test $(L4LB) -test.v $(TEST_VERBOSE)
+
+tests: $(TESTS)
 
 all: plugin
 

--- a/pkg/minuteman/config.go
+++ b/pkg/minuteman/config.go
@@ -1,0 +1,5 @@
+package minuteman
+
+type NetConf struct {
+	Path string `json:"path, omitempty"`
+}

--- a/pkg/minuteman/config.go
+++ b/pkg/minuteman/config.go
@@ -1,5 +1,6 @@
 package minuteman
 
 type NetConf struct {
-	Path string `json:"path, omitempty"`
+	Enable bool   `json:"enable", omitempty"`
+	Path   string `json:"path, omitempty"`
 }

--- a/pkg/minuteman/plugin.go
+++ b/pkg/minuteman/plugin.go
@@ -9,6 +9,8 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 )
 
+const DefaultPath = "/var/run/dcos/cni/l4lb"
+
 func CniAdd(args *skel.CmdArgs) error {
 	conf := &NetConf{}
 	if err := json.Unmarshal(args.StdinData, conf); err != nil {
@@ -16,7 +18,7 @@ func CniAdd(args *skel.CmdArgs) error {
 	}
 
 	if conf.Path == "" {
-		return fmt.Errorf("missing path for minuteman state")
+		conf.Path = DefaultPath
 	}
 
 	// Create the directory where minuteman will search for the
@@ -24,6 +26,8 @@ func CniAdd(args *skel.CmdArgs) error {
 	if err := os.MkdirAll(conf.Path, 0644); err != nil {
 		return fmt.Errorf("couldn't create directory for storing minuteman container registration information:%s", err)
 	}
+
+	fmt.Fprintln(os.Stderr, "Registering netns for containerID", args.ContainerID, " at path: ", conf.Path)
 
 	// Create a file with name `ContainerID` and write the network
 	// namespace into this file.
@@ -43,7 +47,7 @@ func CniDel(args *skel.CmdArgs) error {
 	// For failures just log to `stderr` instead of  failing with an
 	// error.
 	if conf.Path == "" {
-		fmt.Fprintf(os.Stderr, "missing path for minuteman state")
+		conf.Path = DefaultPath
 	}
 
 	// Remove the container registration.

--- a/pkg/minuteman/plugin.go
+++ b/pkg/minuteman/plugin.go
@@ -1,0 +1,55 @@
+package minuteman
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/containernetworking/cni/pkg/skel"
+)
+
+func CniAdd(args *skel.CmdArgs) error {
+	conf := &NetConf{}
+	if err := json.Unmarshal(args.StdinData, conf); err != nil {
+		return fmt.Errorf("failed to load minuteman netconf: %s", err)
+	}
+
+	if conf.Path == "" {
+		return fmt.Errorf("missing path for minuteman state")
+	}
+
+	// Create the directory where minuteman will search for the
+	// registered containers.
+	if err := os.MkdirAll(conf.Path, 0644); err != nil {
+		return fmt.Errorf("couldn't create directory for storing minuteman container registration information:%s", err)
+	}
+
+	// Create a file with name `ContainerID` and write the network
+	// namespace into this file.
+	if err := ioutil.WriteFile(conf.Path+"/"+args.ContainerID, []byte(args.Netns), 0644); err != nil {
+		return fmt.Errorf("couldn't checkout point the network namespace for containerID:%s for minuteman", args.ContainerID)
+	}
+
+	return nil
+}
+
+func CniDel(args *skel.CmdArgs) error {
+	conf := &NetConf{}
+	if err := json.Unmarshal(args.StdinData, conf); err != nil {
+		return fmt.Errorf("failed to load minuteman netconf: %s", err)
+	}
+
+	// For failures just log to `stderr` instead of  failing with an
+	// error.
+	if conf.Path == "" {
+		fmt.Fprintf(os.Stderr, "missing path for minuteman state")
+	}
+
+	// Remove the container registration.
+	if err := os.Remove(conf.Path + "/" + args.ContainerID); err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to remove registration for contianerID:%s from minuteman", args.ContainerID)
+	}
+
+	return nil
+}

--- a/pkg/spartan/config.go
+++ b/pkg/spartan/config.go
@@ -19,6 +19,8 @@ type Network struct {
 	IPAM      IPAM   `json:"ipam"`
 }
 
+const IfName string = "spartan0"
+
 // TODO(asridharan): This needs to be derived from the spartan
 // configuration.
 var IPs = []net.IPNet{

--- a/plugins/l4lb/l4lb.go
+++ b/plugins/l4lb/l4lb.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/dcos/dcos-cni/pkg/minuteman"
 	"github.com/dcos/dcos-cni/pkg/spartan"
 
 	"github.com/containernetworking/cni/pkg/invoke"
@@ -28,11 +29,15 @@ import (
 	"github.com/containernetworking/cni/pkg/version"
 )
 
+// We need this struct for de-duplicating the embedding of
+// `types.NetConf` and `minuteman.NetConf` in `NetConf`.
 type NetConf struct {
 	types.NetConf
-	Args     map[string]interface{} `json:"args"`
-	MTU      int                    `json:"mtu"`
-	Delegate map[string]interface{} `json:"delegate"`
+	Minuteman *minuteman.NetConf     `json:"minuteman, omitempty"`
+	Spartan   bool                   `json:"spartan, omitempty"`
+	Args      map[string]interface{} `json:"args, omitempty"`
+	MTU       int                    `json:"mtu, omitempty"`
+	Delegate  map[string]interface{} `json:"delegate, omitempty"`
 }
 
 func init() {
@@ -87,18 +92,40 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to invoke delegate plugin %s: %s", delegatePlugin, err)
 	}
 
-	// Delegate plugin seems to be successful, install the spartan
-	// network.
+	switch {
+	// Check if minuteman needs to be enabled for this container.
+	case conf.Minuteman != nil:
+		{
+			minutemanArgs := *args
+			minutemanArgs.StdinData, err = json.Marshal(conf.Minuteman)
+			if err != nil {
+				return fmt.Errorf("failed to marshal the minuteman configuration into STDIN for the minuteman plugin")
+			}
 
-	err = spartan.CniAdd(args)
-	if err != nil {
-		return fmt.Errorf("failed to invoke the spartan plugin: %s", err)
+			err = minuteman.CniAdd(&minutemanArgs)
+			if err != nil {
+				return fmt.Errorf("Unable to register container:%s with minuteman", args.ContainerID)
+			}
+		}
+
+	case conf.Spartan:
+		{
+			// Delegate plugin seems to be successful, install the spartan
+			// network.
+			err = spartan.CniAdd(args)
+			if err != nil {
+				return fmt.Errorf("failed to invoke the spartan plugin: %s", err)
+			}
+
+			//TODO(asridharan): We probably need to update the DNS result to
+			//make sure that we override the DNS resolution with the spartan
+			//network, since the operator has explicitly requested to use the
+			//spartan network.
+		}
+
+	default:
+		return fmt.Errorf("at least one of minuteman or spartan CNI options need to be enabled for this plutin")
 	}
-
-	//TODO(asridharan): We probably need to update the DNS result to
-	//make sure that we override the DNS resolution with the spartan
-	//network, since the operator has explicitly requested to use the
-	//spartan network.
 
 	// We always return the result from the delegate plugin and not from
 	// this plugin.
@@ -111,9 +138,33 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to load netconf: %s", err)
 	}
 
-	err := spartan.CniDel(args)
-	if err != nil {
-		return fmt.Errorf("failed to invoke the spartan plugin with CNI_DEL")
+	switch {
+	case conf.Spartan:
+		{
+			err := spartan.CniDel(args)
+			if err != nil {
+				return fmt.Errorf("failed to invoke the spartan plugin with CNI_DEL")
+			}
+		}
+
+	case conf.Minuteman != nil:
+		{
+			var err error
+			minutemanArgs := *args
+			// Check if minuteman entries need to be removed from this container.
+			minutemanArgs.StdinData, err = json.Marshal(conf.Minuteman)
+			if err != nil {
+				return fmt.Errorf("failed to marshal the minuteman configuration into STDIN for the minuteman plugin")
+			}
+
+			err = minuteman.CniDel(&minutemanArgs)
+			if err != nil {
+				return fmt.Errorf("Unable to register container:%s with minuteman", args.ContainerID)
+			}
+		}
+
+	default:
+		return fmt.Errorf("one of minuteman or spartan need to be enabled for this plugin")
 	}
 
 	// Invoke the delegate plugin.

--- a/plugins/l4lb/l4lb_suite_test.go
+++ b/plugins/l4lb/l4lb_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestL4lb(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "L4lb Suite")
+}

--- a/plugins/l4lb/l4lb_test.go
+++ b/plugins/l4lb/l4lb_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"net"
+
+	"github.com/containernetworking/cni/pkg/ip"
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/testutils"
+	"github.com/dcos/dcos-cni/pkg/spartan"
+
+	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("L4lb", func() {
+	var originalNS ns.NetNS
+	var spartanIfName = "spartan"
+
+	BeforeEach(func() {
+		// Create a new NetNS so we don't modify the host
+		var err error
+		originalNS, err = ns.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create dummy spartan interface in this namespace.
+		dummy := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:  spartanIfName,
+				Flags: net.FlagUp,
+				MTU:   1500,
+			},
+		}
+
+		err = netlink.LinkAdd(dummy)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Bring the interface up.
+		err = netlink.LinkSetUp(dummy)
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, spartanIP := range spartan.IPs {
+			// Assign a /32 sparatn IP to this interface.
+			addr := &netlink.Addr{
+				IPNet: &spartanIP,
+				Label: "",
+			}
+			err = netlink.AddrAdd(dummy, addr)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	AfterEach(func() {
+		// Remove the spartan dummy interface.
+		Expect(originalNS.Close()).To(Succeed())
+
+		_, err := ip.DelLinkByNameAddr(spartanIfName, netlink.FAMILY_V4)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures and deconfigures a spartan on a bridge network with ADD/DEL", func() {
+		const IFNAME = "eth0"
+
+		conf := `{
+    	"cniVersion": "0.2.0",
+    	"name": "spartan-net",
+    	"type": "dcos-l4lb",
+			"delegate" : {
+				"type" : "bridge",
+				"bridge": "mesos-cni0",
+    		"ipMasq": true,
+    		"mtu": 5000,
+    		"ipam": {
+        	"type": "host-local",
+        	"subnet": "10.1.2.0/24",
+					"routes": [
+						{ "dst": "0.0.0.0/0" }
+					]
+    		}
+			}
+		}`
+
+		targetNs, err := ns.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+		defer targetNs.Close()
+
+		args := &skel.CmdArgs{
+			ContainerID: "dummy",
+			Netns:       targetNs.Path(),
+			IfName:      IFNAME,
+			StdinData:   []byte(conf),
+		}
+
+		// Execute the plugin with the ADD command, creating the veth
+		// endpoints.
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			_, _, err := testutils.CmdAddWithResult(targetNs.Path(), IFNAME, []byte(conf), func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = targetNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			// Check if the spartan link has been added.
+			link, err := netlink.LinkByName(spartan.IfName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(spartan.IfName))
+
+			// Run the ping command for each of the spartan IP.
+			return nil
+		})
+
+		// Call the plugins with the DEL command, deleting the veth
+		// endpoints.
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := testutils.CmdDelWithResult(targetNs.Path(), IFNAME, func() error {
+				return cmdDel(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Make sure spartan link has been deleted
+		err = targetNs.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			link, err := netlink.LinkByName(spartan.IfName)
+			Expect(err).To(HaveOccurred())
+			Expect(link).To(BeNil())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
The minuteman plugin takes a container ID and network namespace and checkpoints it on disk when we handle CNI ADD, under a specific directory listed in the CNI config. The checkpointing is performed by creating a filename as the `container ID` and the content of the file being a path to the network namespace of the container.

During CNI DEL the plugin just deletes the check-pointed file associated with the container ID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/dcos-cni/2)
<!-- Reviewable:end -->
