### PR TITLE
adds IP address needed by DNS proxy in kubernetes on DC/OS

### DIFF
--- a/pkg/spartan/config.go
+++ b/pkg/spartan/config.go
@@ -40,6 +40,10 @@ var IPs = []net.IPNet{
 		IP:   net.IPv4(198, 51, 100, 3),
 		Mask: net.IPv4Mask(0xff, 0xff, 0xff, 0xff),
 	},
+	net.IPNet{
+		IP:   net.IPv4(198, 51, 100, 4), //used by k8s DNS proxy
+		Mask: net.IPv4Mask(0xff, 0xff, 0xff, 0xff),
+	},
 }
 
 // TODO(asridharan): This needs to be derived from the spartan


### PR DESCRIPTION
Kubernetes on DC/OS runs a DNS proxy that listen on spartan interface.
This patch adds the IP address to the plugin so that appropriate routes
are created in the container using this plugin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/dcos-cni/8)
<!-- Reviewable:end -->
